### PR TITLE
Memory leak fix?

### DIFF
--- a/pdkim.c
+++ b/pdkim.c
@@ -317,6 +317,7 @@ DLLEXPORT void pdkim_free_ctx(pdkim_ctx *ctx) {
   if (ctx) {
     pdkim_free_sig(ctx->sig);
     pdkim_strfree(ctx->cur_header);
+    free(ctx->linebuf);
     free(ctx);
   }
 }


### PR DESCRIPTION
I'm seeing a memory leak and have had other users of my ruby-dkim gem complain about the memory leak, and it looks to me like this fixes it. Does this look right to you or am I missing something?
- Ian
